### PR TITLE
Fix background in devices list

### DIFF
--- a/themes/grey_night.yaml
+++ b/themes/grey_night.yaml
@@ -6,6 +6,7 @@ grey_night:
   accent-color: "hsl(var(--huesat) 30%)"
   base-hue: "220"
   base-sat: "5%"
+  card-background-color: "var(--paper-card-background-color)"
   dark-divider-opacity: "0"
   dark-primary-color: "hsl(var(--huesat) 60%)"
   dark-secondary-opacity: "1"


### PR DESCRIPTION
The device list had a white background. This is a common problem which can be fixed with the variable `card-background-color`. 

[See here](https://github.com/home-assistant/home-assistant-polymer/issues/3772)